### PR TITLE
Schema-Erkennung: Legacy-Angaben vereinheitlichen, variable und gemischte Angaben abweisen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Daraus folgt für jeden Eintrag:
 
 #### Changed
 
+- Eine variable Frequenz (`frequencyMax`) oder Periode (`periodMax`) führt in den täglichen Schemata mit `when` oder `timeOfDay` jetzt zum Abbruch. Bisher wurde sie dort stillschweigend übergangen — `when = MORN` mit `frequencyMax = 3` ergab `1-0-0-0 Stück` und unterschlug die Spanne. Das Profil verbietet die Kombination über `TimingOnlyOneType`; die Schema-Erkennung bildet diese Bedingung jetzt vollständig ab.
 - Ein Mindestabstand zwischen zwei Gaben ist nur bei einer **reinen** Bedarfsdosierung zulässig (`asNeededBoolean = true` ohne `timing`). Tritt er zusammen mit einem strukturierten Rhythmus auf, bricht der Algorithmus ab. Der bisherige Baustein `, mit mindestens {Wert} {Einheit} Abstand` entfällt ersatzlos: Ein Rhythmus legt den Abstand zwischen zwei Gaben bereits fest, `alle 8 Stunden, mit mindestens 6 Stunden Abstand` ließ offen, welche Angabe gilt.
 - Die kanonische URL der Extension für den Mindestabstand lautet `…/StructureDefinition/MinimumIntervalBetweenAdministrations` statt `…/MindestabstandZwischenGaben`.
 - Wochentagsschemata dulden `frequency` sowie das redundante Paar `period = 1`, `periodUnit = wk` als Legacy-Angaben; sie ändern den erzeugten Text nicht. Jede andere Periode ist mit `dayOfWeek` nicht mehr kombinierbar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Daraus folgt für jeden Eintrag:
 
 - Normative Spezifikation [dosage-text-algorithm-spec.md](dosage-text-algorithm-spec.md). Sie ist gegenüber der Referenzimplementierung führend; weicht das Skript ab, gilt die Spezifikation.
 - Abschnitt „Legacy-Angaben" in der Spezifikation: `hatZulaessigeLegacyFelder` und `istTagesmuster` beschreiben denselben Sachverhalt für unterschiedliche Schemata und sind nun gemeinsam erklärt, samt Herkunft der Felder und Abgrenzung zu den Schemata, in denen sie konstituierend sind.
+- Blockquotes in der Spezifikation stehen nur noch für Unverbindliches — Orientierung, Hintergrund, Verweise. Sieben normative Regeln, die bisher als eingerückter Hinweis erschienen, sind Fließtext; das Intro benennt die Konvention.
 - Schema „Kombination von Zeitintervallen": eine nicht tägliche Periode (`d`, `wk` oder `mo`) zusammen mit `when` oder `timeOfDay`. Damit sind wöchentliche und monatliche Rhythmen mit konkreten Zeitpunkten abbildbar.
 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Daraus folgt für jeden Eintrag:
 
 #### Changed
 
+- Enthält eine Ressource mehrere `Dosage`-Elemente, muss jedes zu demselben Schema führen; andernfalls bricht der Algorithmus ab. Bisher bestimmte allein das erste Element das Schema, und ein abweichendes späteres Element entfiel stillschweigend — aus „morgens 1 Stück" und „montags 2 Stück" wurde `1-0-0-0 Stück`.
 - Eine variable Frequenz (`frequencyMax`) oder Periode (`periodMax`) führt in den täglichen Schemata mit `when` oder `timeOfDay` jetzt zum Abbruch. Bisher wurde sie dort stillschweigend übergangen — `when = MORN` mit `frequencyMax = 3` ergab `1-0-0-0 Stück` und unterschlug die Spanne. Das Profil verbietet die Kombination über `TimingOnlyOneType`; die Schema-Erkennung bildet diese Bedingung jetzt vollständig ab.
 - Ein Mindestabstand zwischen zwei Gaben ist nur bei einer **reinen** Bedarfsdosierung zulässig (`asNeededBoolean = true` ohne `timing`). Tritt er zusammen mit einem strukturierten Rhythmus auf, bricht der Algorithmus ab. Der bisherige Baustein `, mit mindestens {Wert} {Einheit} Abstand` entfällt ersatzlos: Ein Rhythmus legt den Abstand zwischen zwei Gaben bereits fest, `alle 8 Stunden, mit mindestens 6 Stunden Abstand` ließ offen, welche Angabe gilt.
 - Die kanonische URL der Extension für den Mindestabstand lautet `…/StructureDefinition/MinimumIntervalBetweenAdministrations` statt `…/MindestabstandZwischenGaben`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Daraus folgt für jeden Eintrag:
 #### Added
 
 - Normative Spezifikation [dosage-text-algorithm-spec.md](dosage-text-algorithm-spec.md). Sie ist gegenüber der Referenzimplementierung führend; weicht das Skript ab, gilt die Spezifikation.
+- Abschnitt „Legacy-Angaben" in der Spezifikation: `hatZulaessigeLegacyFelder` und `istTagesmuster` beschreiben denselben Sachverhalt für unterschiedliche Schemata und sind nun gemeinsam erklärt, samt Herkunft der Felder und Abgrenzung zu den Schemata, in denen sie konstituierend sind.
 - Schema „Kombination von Zeitintervallen": eine nicht tägliche Periode (`d`, `wk` oder `mo`) zusammen mit `when` oder `timeOfDay`. Damit sind wöchentliche und monatliche Rhythmen mit konkreten Zeitpunkten abbildbar.
 
 #### Changed

--- a/dosage-text-algorithm-spec.md
+++ b/dosage-text-algorithm-spec.md
@@ -310,7 +310,22 @@ Abgeleitete Hilfsbedingungen:
 * `istReinesIntervall` = `hatFrequenz` **und** `hatPeriode` **und** `hatPeriodeneinheit` **und nicht** (`hatWhenCodes` oder `hatUhrzeit` oder `hatWochentag`)
 * `hatZulaessigeLegacyFelder` = **nicht** `hatFrequenzMax` **und nicht** `hatPeriodenMax` **und** ((**nicht** `hatPeriode` **und nicht** `hatPeriodeneinheit`) **oder** (`repeat.period = 1` **und** `repeat.periodUnit = 'wk'`))
 
-Zu `hatZulaessigeLegacyFelder`: Wochentagsschemata wiederholen sich implizit wöchentlich. `frequency` und das vollständige Paar `period = 1`, `periodUnit = wk` dürfen aus Gründen der Rückwärtskompatibilität redundant mitgeführt werden und ändern die Ausgabe nicht. Jede andere Periode beschreibt ein echtes Intervall und ist mit `dayOfWeek` nicht kombinierbar; eine variable Frequenz oder Periode ebenfalls nicht, weil Wochentage die Zahl der Anwendungen bereits festlegen.
+#### Legacy-Angaben
+
+In früheren Fassungen des Medication IG DE waren `frequency`, `period` und `periodUnit` in **allen** Dosierschemata verpflichtend — auch dort, wo sie nur wiederholen, was Wochentage, Tagesabschnitte oder Uhrzeiten bereits ausdrücken. Sie sind heute nur noch dort erforderlich, wo sie tatsächlich ein Intervall beschreiben. Damit bestehende Verordnungsdaten gültig bleiben, werden sie weiterhin geduldet. Sie begründen kein Intervallschema und **ändern die Ausgabe nicht**: Eine Ressource mit und eine ohne diese Felder erzeugen denselben Text.
+
+Zwei der oben genannten Hilfsbedingungen beschreiben denselben Sachverhalt für unterschiedliche Schemata und unterscheiden sich nur in der Periodeneinheit:
+
+| Bedingung | geduldetes Paar | verwendet in |
+|---|---|---|
+| `hatZulaessigeLegacyFelder` | `period = 1`, `periodUnit = wk` | Regel 4 und 5 (Wochentage) |
+| `istTagesmuster` | `period = 1`, `periodUnit = d` | Regel 3 und 6 (Tagesabschnitte, Uhrzeiten) |
+
+`frequency` wird in keiner der beiden Bedingungen geprüft: In diesen Schemata beeinflusst es die Schema-Erkennung nicht und wird nicht ausgegeben, weil die konkreten Zeitpunkte die Zahl der Gaben bereits festlegen. Die Invariante `TimingFrequencyCount` des Profils stellt sicher, dass ein angegebener Wert dieser Anzahl entspricht. Nur bei **wiederkehrenden Intervallen** (Regel 8) ist `frequency` keine Legacy-Angabe: Dort ist es konstituierend und erscheint im Text, etwa als `2 x alle 8 Stunden`.
+
+Wochentagsschemata wiederholen sich implizit wöchentlich, tägliche Schemata implizit täglich — daher die unterschiedliche Einheit. Jede **andere** Periode beschreibt ein echtes Intervall: Bei `dayOfWeek` ist sie unzulässig, bei `when` oder `timeOfDay` führt sie über `istNichtTagesmuster` zu Regel 7. Eine variable Frequenz oder Periode ist bei Wochentagen ebenfalls ausgeschlossen, weil die Wochentage die Zahl der Anwendungen bereits festlegen.
+
+Im Schema **Kombination von Zeitintervallen** (Regel 7) ist ausschließlich `frequency` eine Legacy-Angabe; `period` und `periodUnit` legen dort den Rhythmus fest.
 
 ### Prioritätsreihenfolge
 

--- a/dosage-text-algorithm-spec.md
+++ b/dosage-text-algorithm-spec.md
@@ -307,21 +307,21 @@ Bevor die Bausteine zusammengesetzt werden, wird genau **ein** Darstellungsschem
 
 Abgeleitete Hilfsbedingungen:
 
-* `istTagesmuster` = `repeat.period = 1` **und** `repeat.periodUnit = 'd'` **und nicht** `hatPeriodenMax`
+* `istTagesmuster` = `repeat.period = 1` **und** `repeat.periodUnit = 'd'` **und nicht** `hatPeriodenMax` — dient nur der Abgrenzung von `istNichtTagesmuster` in Regel 7
 * `istNichtTagesmuster` = `hatPeriode` **und** `hatPeriodeneinheit` **und nicht** `istTagesmuster`
 * `istReinesIntervall` = `hatFrequenz` **und** `hatPeriode` **und** `hatPeriodeneinheit` **und nicht** (`hatWhenCodes` oder `hatUhrzeit` oder `hatWochentag`)
-* `hatZulaessigeLegacyFelder` = **nicht** `hatFrequenzMax` **und nicht** `hatPeriodenMax` **und** ((**nicht** `hatPeriode` **und nicht** `hatPeriodeneinheit`) **oder** (`repeat.period = 1` **und** `repeat.periodUnit = 'wk'`))
+* `hatZulaessigeLegacyFelder(einheit)` = **nicht** `hatFrequenzMax` **und nicht** `hatPeriodenMax` **und** ((**nicht** `hatPeriode` **und nicht** `hatPeriodeneinheit`) **oder** (`repeat.period = 1` **und** `repeat.periodUnit = einheit`))
 
 #### Legacy-Angaben
 
 In früheren Fassungen des Medication IG DE waren `frequency`, `period` und `periodUnit` in **allen** Dosierschemata verpflichtend — auch dort, wo sie nur wiederholen, was Wochentage, Tagesabschnitte oder Uhrzeiten bereits ausdrücken. Sie sind heute nur noch dort erforderlich, wo sie tatsächlich ein Intervall beschreiben. Damit bestehende Verordnungsdaten gültig bleiben, werden sie weiterhin geduldet. Sie begründen kein Intervallschema und **ändern die Ausgabe nicht**: Eine Ressource mit und eine ohne diese Felder erzeugen denselben Text.
 
-Zwei der oben genannten Hilfsbedingungen beschreiben denselben Sachverhalt für unterschiedliche Schemata und unterscheiden sich nur in der Periodeneinheit:
+Die Bedingung `hatZulaessigeLegacyFelder` gilt für alle vier betroffenen Schemata; sie unterscheiden sich nur in der Periodeneinheit, die sich aus der impliziten Wiederholung des Schemas ergibt:
 
-| Bedingung | geduldetes Paar | verwendet in |
+| Aufruf | geduldetes Paar | verwendet in |
 |---|---|---|
-| `hatZulaessigeLegacyFelder` | `period = 1`, `periodUnit = wk` | Regel 4 und 5 (Wochentage) |
-| `istTagesmuster` | `period = 1`, `periodUnit = d` | Regel 3 und 6 (Tagesabschnitte, Uhrzeiten) |
+| `hatZulaessigeLegacyFelder('wk')` | `period = 1`, `periodUnit = wk` | Regel 4 und 5 (Wochentage) |
+| `hatZulaessigeLegacyFelder('d')` | `period = 1`, `periodUnit = d` | Regel 3 und 6 (Tagesabschnitte, Uhrzeiten) |
 
 `frequency` wird in keiner der beiden Bedingungen geprüft: In diesen Schemata beeinflusst es die Schema-Erkennung nicht und wird nicht ausgegeben, weil die konkreten Zeitpunkte die Zahl der Gaben bereits festlegen. Die Invariante `TimingFrequencyCount` des Profils stellt sicher, dass ein angegebener Wert dieser Anzahl entspricht. Nur bei **wiederkehrenden Intervallen** (Regel 8) ist `frequency` keine Legacy-Angabe: Dort ist es konstituierend und erscheint im Text, etwa als `2 x alle 8 Stunden`.
 
@@ -337,10 +337,10 @@ Die Regeln werden **von oben nach unten** geprüft; die **erste** zutreffende Re
 |---|--------|-----------|
 | 1 | **Freitext-Dosierung** | `hatText` **und nicht** `hatTiming` **und nicht** `hatDosis` |
 | 2 | **Bedarfsmedikation (rein)** | `istBedarf` **und nicht** `hatTiming` |
-| 3 | **4-Schema** (Tageszeiten) | `hatWhenCodes` **und nicht** `hatUhrzeit` **und nicht** `hatWochentag` **und** (`istTagesmuster` **oder** (nicht `hatPeriode` **und** nicht `hatPeriodeneinheit`)) |
-| 4 | **Wochentags-Bezug** | `hatWochentag` **und nicht** `hatWhenCodes` **und nicht** `hatUhrzeit` **und** `hatZulaessigeLegacyFelder` |
-| 5 | **Kombination von Wochentagen** | `hatWochentag` **und** (`hatUhrzeit` **oder** `hatWhenCodes`) **und** `hatZulaessigeLegacyFelder` |
-| 6 | **Uhrzeiten-Bezug** | `hatUhrzeit` **und nicht** `hatWochentag` **und nicht** `hatWhenCodes` **und** (`istTagesmuster` **oder** (nicht `hatPeriode` **und** nicht `hatPeriodeneinheit`)) |
+| 3 | **4-Schema** (Tageszeiten) | `hatWhenCodes` **und nicht** `hatUhrzeit` **und nicht** `hatWochentag` **und** `hatZulaessigeLegacyFelder('d')` |
+| 4 | **Wochentags-Bezug** | `hatWochentag` **und nicht** `hatWhenCodes` **und nicht** `hatUhrzeit` **und** `hatZulaessigeLegacyFelder('wk')` |
+| 5 | **Kombination von Wochentagen** | `hatWochentag` **und** (`hatUhrzeit` **oder** `hatWhenCodes`) **und** `hatZulaessigeLegacyFelder('wk')` |
+| 6 | **Uhrzeiten-Bezug** | `hatUhrzeit` **und nicht** `hatWochentag` **und nicht** `hatWhenCodes` **und** `hatZulaessigeLegacyFelder('d')` |
 | 7 | **Kombination von Zeitintervallen** | `istNichtTagesmuster` **und** (`hatUhrzeit` **oder** `hatWhenCodes`) **und nicht** `hatWochentag` **und** `repeat.periodUnit` ∈ {`d`, `wk`, `mo`} |
 | 8 | **Wiederkehrende Intervalle** | `istReinesIntervall` |
 | – | **Abbruch** | trifft keine Regel zu |

--- a/dosage-text-algorithm-spec.md
+++ b/dosage-text-algorithm-spec.md
@@ -8,7 +8,9 @@ Voraussetzung für eine erfolgreiche Texterzeugung ist stets ein **profilkonform
 
 Diese Seite stellt zwei Aspekte dar: **Teil A** beschreibt, wie jede einzelne Angabe einer `Dosage` in Text überführt wird. **Teil B** beschreibt, wie diese Bausteine je zulässigem Schema zu einem vollständigen Dosierungstext zusammengesetzt werden.
 
-> Hinweis zur Bereichsdarstellung: Variable Angaben (Frequenz, Periode, Einzeldosis) werden durchgängig mit dem Wort **„bis"** gebildet (z. B. „1 bis 2 Stück"). Enthält das kompakte 4‑Schema einen variablen Wert, wird es in die ausgeschriebene Segmentform überführt (siehe [4‑Schema](#schema-mit-tageszeiten-bezug-4-schema)).
+Der gesamte Fließtext dieser Seite ist verbindlich. Eingerückte Blöcke enthalten ausschließlich Unverbindliches: Orientierungshilfen, Hintergrund und Verweise auf andere Dokumente.
+
+**Zur Bereichsdarstellung** — festgelegt in den jeweiligen Abschnitten, hier vorab zur Orientierung: Variable Angaben (Frequenz, Periode, Einzeldosis) werden durchgängig mit dem Wort **„bis"** gebildet (z. B. „1 bis 2 Stück"). Enthält das kompakte 4‑Schema einen variablen Wert, wird es in die ausgeschriebene Segmentform überführt (siehe [4‑Schema](#schema-mit-tageszeiten-bezug-4-schema)).
 
 ---
 
@@ -62,7 +64,7 @@ Es wird ausschließlich `doseAndRate[0]` ausgewertet. Ist dort `doseQuantity` vo
 * beidseitig: `je {von} bis {bis} {Einheit}` (z. B. `je 1 bis 2 Stück`)
 * nur obere Grenze: `je bis zu {bis} {Einheit}` (z. B. `je bis zu 2 Stück`)
 
-> Nur die untere Grenze (`low` ohne `high`) ist **nicht zulässig** und wird durch die Invariante `DoseRangeHighRequiredWhenLowPresent` ausgeschlossen.
+Nur die untere Grenze (`low` ohne `high`) ist **nicht zulässig** und wird durch die Invariante `DoseRangeHighRequiredWhenLowPresent` ausgeschlossen.
 
 Ganzzahlige Werte werden ohne Nachkommastelle dargestellt; überflüssige Dezimalstelle und Komma entfallen (`1.0` → `1`). Dezimalwerte werden mit **deutschem Dezimalkomma** ausgegeben (z. B. `1,5`). Die maximale Anzahl von Nachkommastellen ist nicht eingeschränkt; Werte werden verlustfrei ohne Rundung übernommen. Die Verantwortung für sinnvolle Präzision (z. B. nicht mehr als 2 Nachkommastellen) liegt beim aufrufenden System.
 
@@ -235,7 +237,7 @@ Ergänzende Einnahmehinweise werden aus `patientInstruction` (einzelner String, 
 
 Der Hinweis wird als **eigener Satz** angehängt. Der bisherige strukturierte Dosierungstext erhält einen abschließenden Punkt, gefolgt von `Hinweis: {Text}`. Ist bereits ein Punkt vorhanden, wird kein zweiter ergänzt. Bei profilkonformen Eingaben erzeugt der Algorithmus den Punkt regulär beim Anhängen des Hinweises. Beispiel: `1-0-1-0 Stück. Hinweis: Nach dem Essen`.
 
-> `additionalInstruction` wird **nicht** verwendet und ist im Profil `DosageDgMP` auf `0..0` gestrichen; es bleibt für künftige strukturierte Zusatzangaben reserviert.
+`additionalInstruction` wird **nicht** verwendet und ist im Profil `DosageDgMP` auf `0..0` gestrichen; es bleibt für künftige strukturierte Zusatzangaben reserviert.
 
 Auch `route` wird vom Algorithmus nicht gelesen oder ausgegeben; es steht in der Liste zukünftig unterstützter Dosierkonfigurationen (siehe [Beispiele von erzeugten Dosiertexten](https://ig.fhir.de/igs/medication/dosierung-beispiele.html)).
 
@@ -266,7 +268,7 @@ Die folgenden Zeichen sind für den erzeugten Text **verbindlich festgelegt**. M
 
 Für die Umlaute in den festen Wortbestandteilen (`täglich`, `wöchentlich`, `für`) gilt die **vorkomponierte NFC-Form**: `ä` U+00E4, `ö` U+00F6, `ü` U+00FC — **nicht** die zerlegte Form aus Grundbuchstabe und kombinierendem Trema (`a` + U+0308). Der gesamte erzeugte Text ist NFC-normalisiert. Ein `ß` kommt in keinem vom Algorithmus erzeugten Wortbestandteil vor.
 
-> Nicht Teil dieses Repertoires sind Zeichen, die **unverändert aus dem Input übernommen** werden: die Dosiereinheit (`doseQuantity.unit`), der Einnahmeanlass (`asNeededFor`), der Hinweis (`patientInstruction`) und der Freitext (`Dosage.text`). Sie werden weder ersetzt noch normalisiert.
+Nicht Teil dieses Repertoires sind Zeichen, die **unverändert aus dem Input übernommen** werden: die Dosiereinheit (`doseQuantity.unit`), der Einnahmeanlass (`asNeededFor`), der Hinweis (`patientInstruction`) und der Freitext (`Dosage.text`). Sie werden weder ersetzt noch normalisiert.
 
 Strukturierte Schemata erzeugen keine Zeilenumbrüche; ihr Text steht in einer Zeile. Die Freitext-Dosierung durchläuft die nachfolgende Normalisierung nicht und kann daher im Feld enthaltene Zeilenumbrüche beibehalten; lediglich der unter [Freitext-Dosierung](#freitext-dosierung) beschriebene `trim` wird angewendet. Diese Ausnahme ist notwendig, weil die Invariante `FreeTextMatchesRenderedText` exakte Gleichheit zwischen `renderedDosageInstruction` und `Dosage.text` verlangt.
 
@@ -343,7 +345,7 @@ Die Regeln werden **von oben nach unten** geprüft; die **erste** zutreffende Re
 | 8 | **Wiederkehrende Intervalle** | `istReinesIntervall` |
 | – | **Abbruch** | trifft keine Regel zu |
 
-> **Bedarf als Querschnittsmerkmal:** Nur der **reine** Bedarf (ohne `timing`, Regel 2) ist ein eigenes Schema. Ist zusätzlich ein `timing` vorhanden, wird über die Regeln 3–8 das strukturierte Schema bestimmt; die Bedarfskennzeichnung (`asNeededBoolean`, Einnahmeanlass, Mindestabstand, Maximalmenge) wird dann beim Zusammensetzen als Präfix/Suffix ergänzt (siehe [Schema für Bedarfsmedikation](#schema-für-bedarfsmedikation)).
+**Bedarf als Querschnittsmerkmal:** Nur der **reine** Bedarf (ohne `timing`, Regel 2) ist ein eigenes Schema. Ist zusätzlich ein `timing` vorhanden, wird über die Regeln 3–8 das strukturierte Schema bestimmt; die Bedarfskennzeichnung (`asNeededBoolean`, Einnahmeanlass, Mindestabstand, Maximalmenge) wird dann beim Zusammensetzen als Präfix/Suffix ergänzt (siehe [Schema für Bedarfsmedikation](#schema-für-bedarfsmedikation)).
 
 ---
 
@@ -375,7 +377,7 @@ Die Werte werden über alle `Dosage`-Elemente eingesammelt. Für jedes Element w
 
 *Beispiel:* `für 5 Tage: 1-1-1-1 Kapseln`
 
-> **Variabilität:** Enthält eine der Positionen einen variablen Wert (Bereich), wird das kompakte Schema in die ausgeschriebene Segmentform (nur belegte Positionen) überführt, z. B. `morgens — je 1 bis 2 Stück, abends — je 2 Stück`. Feste 4‑Schemata bleiben kompakt (`1-0-2-0 Stück`).
+**Variabilität:** Enthält eine der Positionen einen variablen Wert (Bereich), wird das kompakte Schema in die ausgeschriebene Segmentform (nur belegte Positionen) überführt, z. B. `morgens — je 1 bis 2 Stück, abends — je 2 Stück`. Feste 4‑Schemata bleiben kompakt (`1-0-2-0 Stück`).
 
 ### Schema mit Uhrzeiten-Bezug
 
@@ -439,7 +441,7 @@ Jeder belegte Tag bildet mit seinen Uhrzeiten oder seinem Tagesabschnitts-Muster
 
 Bei der Kombination mit Tagesabschnitten stammt die gemeinsame Einheit aus dem ersten Element mit auswertbarer Dosis. Wird bei nicht profilkonformem Input dieselbe Kombination aus Wochentag und Tagesabschnitt mehrfach mit unterschiedlicher Dosis belegt, bricht der Algorithmus ab: `ValueError("Doppelte Belegung der Kombination aus Wochentag '{code}' und Zeit-/Tagesabschnitt '{zeit}' mit unterschiedlicher Dosis.")` Wie beim reinen Wochentags-Schema beeinflussen `frequency` sowie das redundante Paar `period = 1`, `periodUnit = wk` die Ausgabe nicht. `frequencyMax`, `periodMax` und jede andere Periode sind in diesem Schema nicht zulässig (siehe [Schema-Erkennung](#schema-erkennung)).
 
-> **Variabilität:** Enthält **irgendein** Tag einen variablen Wert (Bereich), wird die ausgeschriebene Segmentform für **alle** Tage verwendet, damit die Notation über den gesamten Text einheitlich bleibt — z. B. `montags morgens — je 1 bis 2 Stück; mittwochs abends — je 2 Stück`. Sind alle Werte fest, bleiben alle Tage kompakt (`montags 1-0-1-0 Stück; mittwochs 2-1-2-0 Stück`).
+**Variabilität:** Enthält **irgendein** Tag einen variablen Wert (Bereich), wird die ausgeschriebene Segmentform für **alle** Tage verwendet, damit die Notation über den gesamten Text einheitlich bleibt — z. B. `montags morgens — je 1 bis 2 Stück; mittwochs abends — je 2 Stück`. Sind alle Werte fest, bleiben alle Tage kompakt (`montags 1-0-1-0 Stück; mittwochs 2-1-2-0 Stück`).
 
 ### Schema für Bedarfsmedikation
 
@@ -511,7 +513,7 @@ Die folgende Tabelle nennt für jeden dynamischen Baustein den genauen Lese-Pfad
 * Einnahmeanlass: `http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor`
 * Mindestabstand: `http://ig.fhir.de/igs/medication/StructureDefinition/MinimumIntervalBetweenAdministrations`
 
-> Beide Extensions werden über ihre **exakte kanonische `url`** identifiziert.
+Beide Extensions werden über ihre **exakte kanonische `url`** identifiziert.
 
 > Zur `asNeededFor`-Extension: Die kanonische URL `http://hl7.org/fhir/5.0/StructureDefinition/extension-Dosage.asNeededFor` stammt aus FHIR R5, wird hier aber gemäß dem Cross-Version-Extension-Pattern bewusst für ein R4-Profil (FHIR 4.0.1) zurückportiert. Das ist ein im FHIR-Ökosystem etabliertes Vorgehen, um R5-Konzepte in R4-Implementierungen vorwegzunehmen.
 

--- a/dosage-text-algorithm-spec.md
+++ b/dosage-text-algorithm-spec.md
@@ -45,6 +45,8 @@ und anzahl(dosierungen) != 1:
 
 schema = erkenneSchema(dosierungen[0])
 wenn schema unbekannt: Fehler
+fuer jede weitere dosierung:
+  wenn erkenneSchema(dosierung) != schema: Fehler
 
 text = erzeugeSchemaspezifischenText(schema, dosierungen)
 wenn schema = Freitext: return text
@@ -286,7 +288,9 @@ Der Gedankenstrich (`—`) und Klammern bleiben dabei unangetastet.
 
 ## Schema-Erkennung
 
-Bevor die Bausteine zusammengesetzt werden, wird genau **ein** Darstellungsschema bestimmt. Grundlage der Erkennung ist das **erste `Dosage`-Element** der Ressource; der profilkonforme Input stellt sicher, dass alle weiteren Elemente strukturell dazu passen und nur zusätzliche Segmente beisteuern.
+Bevor die Bausteine zusammengesetzt werden, wird genau **ein** Darstellungsschema bestimmt. Es gilt für die gesamte Ressource: Enthält sie mehrere `Dosage`-Elemente, muss **jedes** zu demselben Schema führen, sonst bricht der Algorithmus ab. Grundlage der Erkennung ist zwar das erste Element, ein abweichendes späteres Element würde bei der Textbildung aber übergangen — und mit ihm eine vollständige Gabe: Aus „morgens 1 Stück" und „montags 2 Stück" entstünde kommentarlos `1-0-0-0 Stück`. Die Invarianten `TimingOnlyOneType` und `TimingOnlyWhenOrTimeOfDay` schließen das für profilkonformen Input aus; der Algorithmus verlässt sich darauf nicht.
+
+ Grundlage der Erkennung ist das **erste `Dosage`-Element** der Ressource; der profilkonforme Input stellt sicher, dass alle weiteren Elemente strukturell dazu passen und nur zusätzliche Segmente beisteuern.
 
 ### Ausgewertete Merkmale (auf `timing.repeat` des ersten Elements)
 
@@ -553,6 +557,7 @@ Die formale Definition zulässiger Felder und Kombinationen liegt in den Timing-
 * `doseRange` ohne erforderliche obere Grenze: Abbruch mit `ValueError("doseRange.high.value ist für die Textgenerierung erforderlich.")`; eine fehlende Einheit führt entsprechend zu `ValueError("doseRange.high.unit ist für die Textgenerierung erforderlich.")`
 * `doseRange.high.value <= 0`: Abbruch mit `ValueError("doseRange.high.value muss größer als 0 sein.")`
 * vorhandenes `doseRange.low` ohne `.value` oder `.unit`: Abbruch mit der entsprechenden Fehlermeldung für `doseRange.low.value` beziehungsweise `doseRange.low.unit`
+* mehrere `Dosage`-Elemente mit unterschiedlichem Schema: Abbruch mit `ValueError("Alle Dosage-Elemente müssen demselben Schema folgen; Element 1 ergibt '{schema1}', Element {n} '{schemaN}'.")`
 * vorhandenes `doseRange.low.value < 0`: Abbruch mit `ValueError("doseRange.low.value darf nicht negativ sein.")`. Der Wert `0` ist hier — anders als bei `doseQuantity` und `doseRange.high` — zulässig, weil er die Untergrenze einer variablen Dosis wie „0 bis 2 Stück“ bildet
 * unterschiedliche Einheiten in `doseRange.low` und `doseRange.high`: Abbruch mit `ValueError("doseRange.low.unit und doseRange.high.unit müssen übereinstimmen.")`
 * vorhandenes `boundsDuration` ohne `.value` oder `.code`: Abbruch mit einer entsprechenden Pflichtfeldmeldung; ein nicht numerischer Wert oder ein Wert `<= 0` führt zu `ValueError("boundsDuration.value muss größer als 0 sein.")`

--- a/medication-dosage-to-text.py
+++ b/medication-dosage-to-text.py
@@ -169,6 +169,22 @@ class MedicationDosageTextGenerator:
         # Step 2: Determine which dosage schema applies (implements TimingOnlyOneType logic)
         schema_type = self._determine_dosage_schema(dosage_instructions)
 
+        # Die Erkennung stützt sich auf das erste Dosage-Element. Gehörte ein
+        # späteres Element zu einem anderen Schema, würde es bei der Textbildung
+        # übergangen — und mit ihm eine vollständige Gabe: Aus „morgens 1 Stück"
+        # plus „montags 2 Stück" entstünde kommentarlos „1-0-0-0 Stück". Die
+        # Invarianten TimingOnlyOneType und TimingOnlyWhenOrTimeOfDay schließen
+        # das aus; der Algorithmus verlässt sich darauf nicht, weil eine
+        # unterschlagene Dosis der gefährlichste Ausgang wäre.
+        for position, dosage in enumerate(dosage_instructions[1:], start=2):
+            other_schema = self._determine_dosage_schema([dosage])
+            if other_schema != schema_type:
+                raise ValueError(
+                    "Alle Dosage-Elemente müssen demselben Schema folgen; "
+                    f"Element 1 ergibt '{schema_type}', Element {position} "
+                    f"'{other_schema}'."
+                )
+
         # Step 3: Generate text using the appropriate schema-specific method
         text_generators = {
             self.SCHEMA_FREE_TEXT: self._generate_freetext_schema_text,

--- a/medication-dosage-to-text.py
+++ b/medication-dosage-to-text.py
@@ -292,21 +292,32 @@ class MedicationDosageTextGenerator:
         is_non_daily_pattern = (has_period and has_period_unit and not is_daily_pattern)
         is_pure_interval = (has_frequency and has_period and has_period_unit and
                             not has_when_codes and not has_time_of_day and not has_day_of_week)
-        has_valid_weekday_legacy_fields = (
-            'frequencyMax' not in repeat_element and
-            'periodMax' not in repeat_element and
-            (
-                (not has_period and not has_period_unit) or
-                (repeat_element.get('period') == 1 and
-                 repeat_element.get('periodUnit') == 'wk')
+        def has_valid_legacy_fields(period_unit):
+            """Geduldete Legacy-Angaben fuer ein Schema mit impliziter Wiederholung.
+
+            frequency wird hier nicht geprueft: Es beeinflusst die Erkennung nicht
+            und wird nie ausgegeben. Eine variable Frequenz oder Periode ist dagegen
+            ausgeschlossen - die konkreten Zeitpunkte legen die Zahl der Gaben
+            bereits fest, eine Spanne daneben liesse sich nur unterschlagen.
+            """
+            return (
+                'frequencyMax' not in repeat_element and
+                'periodMax' not in repeat_element and
+                (
+                    (not has_period and not has_period_unit) or
+                    (repeat_element.get('period') == 1 and
+                     repeat_element.get('periodUnit') == period_unit)
+                )
             )
-        )
+
+        has_valid_weekday_legacy_fields = has_valid_legacy_fields('wk')
+        has_valid_daily_legacy_fields = has_valid_legacy_fields('d')
 
         # Schema 3: 4-Schema. Konkrete Tagesabschnitte legen die Zahl der Gaben
         # bereits fest. frequency sowie das tägliche period/periodUnit-Paar sind
         # optional und ändern die Textausgabe nicht.
         if (has_when_codes and not has_time_of_day and not has_day_of_week and
-                (is_daily_pattern or (not has_period and not has_period_unit))):
+                has_valid_daily_legacy_fields):
             return self.SCHEMA_4_PATTERN
 
         # Schema 4: DayOfWeek. frequency/period/periodUnit may be present as
@@ -324,7 +335,7 @@ class MedicationDosageTextGenerator:
         # Schema 6: TimeOfDay. frequency sowie das tägliche
         # period/periodUnit-Paar sind optional und ändern die Textausgabe nicht.
         if (has_time_of_day and not has_day_of_week and not has_when_codes and
-                (is_daily_pattern or (not has_period and not has_period_unit))):
+                has_valid_daily_legacy_fields):
             return self.SCHEMA_TIME_OF_DAY
 
         # Schema 7: Äußeres, nicht tägliches Intervall mit konkreten Zeitpunkten.

--- a/tests/test_regression_ordering.py
+++ b/tests/test_regression_ordering.py
@@ -600,3 +600,47 @@ class SchemaOutputTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class DailyLegacyFieldsTest(unittest.TestCase):
+    """Variable Angaben sind in den taeglichen Schemata unzulaessig.
+
+    Frueher wurden frequencyMax und periodMax dort stillschweigend uebergangen:
+    "when + frequencyMax" ergab 1-0-0-0 Stueck und unterschlug die Spanne. Das
+    Profil verbietet die Kombination ueber TimingOnlyOneType; der Algorithmus
+    bricht jetzt ebenfalls ab.
+    """
+
+    def setUp(self):
+        self.generator = MODULE.MedicationDosageTextGenerator()
+
+    def _resource(self, dosage_instructions):
+        return {"resourceType": "MedicationRequest",
+                "dosageInstruction": dosage_instructions}
+
+    def _dosage(self, **repeat):
+        return {
+            "timing": {"repeat": repeat},
+            "doseAndRate": [{"doseQuantity": {"value": 1, "unit": "Stück"}}],
+        }
+
+    def test_variable_frequency_or_period_is_rejected_in_daily_schemas(self):
+        for repeat in (
+            {"when": ["MORN"], "frequencyMax": 3},
+            {"when": ["MORN"], "periodMax": 3},
+            {"timeOfDay": ["08:00:00"], "frequencyMax": 3},
+            {"timeOfDay": ["08:00:00"], "periodMax": 3},
+        ):
+            with self.subTest(repeat=repeat):
+                with self.assertRaises(ValueError):
+                    self.generator.generate_dosage_text(
+                        self._resource([self._dosage(**repeat)])
+                    )
+
+    def test_daily_legacy_pair_still_produces_the_same_text(self):
+        ohne = self._dosage(when=["MORN", "EVE"])
+        mit = self._dosage(when=["MORN", "EVE"], frequency=2, period=1, periodUnit="d")
+        self.assertEqual(
+            self.generator.generate_dosage_text(self._resource([ohne])),
+            self.generator.generate_dosage_text(self._resource([mit])),
+        )

--- a/tests/test_regression_ordering.py
+++ b/tests/test_regression_ordering.py
@@ -644,3 +644,56 @@ class DailyLegacyFieldsTest(unittest.TestCase):
             self.generator.generate_dosage_text(self._resource([ohne])),
             self.generator.generate_dosage_text(self._resource([mit])),
         )
+
+
+class MixedSchemaTest(unittest.TestCase):
+    """Alle Dosage-Elemente muessen demselben Schema folgen.
+
+    Die Schema-Erkennung stuetzt sich auf das erste Element. Frueher wurde ein
+    abweichendes spaeteres Element bei der Textbildung uebergangen - und mit ihm
+    eine vollstaendige Gabe: "morgens 1 Stueck" plus "montags 2 Stueck" ergab
+    kommentarlos "1-0-0-0 Stueck".
+    """
+
+    def setUp(self):
+        self.generator = MODULE.MedicationDosageTextGenerator()
+
+    def _dosage(self, dose, **repeat):
+        return {
+            "timing": {"repeat": repeat},
+            "doseAndRate": [{"doseQuantity": {"value": dose, "unit": "Stück"}}],
+        }
+
+    def _text(self, *dosages):
+        return self.generator.generate_dosage_text(
+            {"resourceType": "MedicationRequest", "dosageInstruction": list(dosages)}
+        )
+
+    def test_mixed_schemas_are_rejected(self):
+        cases = (
+            (self._dosage(1, when=["MORN"]), self._dosage(2, dayOfWeek=["mon"])),
+            (self._dosage(1, dayOfWeek=["mon"]), self._dosage(2, when=["EVE"])),
+            (self._dosage(1, when=["MORN"]), self._dosage(2, timeOfDay=["20:00:00"])),
+            (self._dosage(1, when=["MORN"]),
+             self._dosage(2, frequency=1, period=8, periodUnit="h")),
+            (self._dosage(1, when=["MORN"]), self._dosage(2, when=["EVE"], periodMax=3)),
+        )
+        for first, second in cases:
+            with self.subTest(second=second["timing"]["repeat"]):
+                with self.assertRaises(ValueError):
+                    self._text(first, second)
+
+    def test_same_schema_across_elements_still_works(self):
+        self.assertEqual(
+            self._text(self._dosage(1, when=["MORN"]), self._dosage(2, when=["EVE"])),
+            "1-0-2-0 Stück",
+        )
+
+    def test_legacy_fields_in_only_one_element_do_not_split_the_schema(self):
+        self.assertEqual(
+            self._text(
+                self._dosage(1, when=["MORN"]),
+                self._dosage(2, when=["EVE"], frequency=2, period=1, periodUnit="d"),
+            ),
+            "1-0-2-0 Stück",
+        )


### PR DESCRIPTION
Fünf Änderungen an der Schema-Erkennung und den Bedarfsangaben. Zwei redaktionell, drei am Verhalten bei nicht profilkonformem Input.

## 1. Legacy-Angaben zusammenhängend erklärt (redaktionell)

Der Begriff stand nur beim Wochentagsschema. Denselben Sachverhalt für Tagesabschnitte und Uhrzeiten trug `istTagesmuster`, ohne als Legacy bezeichnet zu werden. Jetzt ein eigener Abschnitt mit beiden Fällen, Herkunft der Felder und Abgrenzung zu den Schemata, in denen sie konstituierend sind.

## 2. Blockquotes nur noch für Unverbindliches (redaktionell)

`>` stand für Nebenbemerkungen, normative Teilregeln und eine Zusammenfassung gleichermaßen. Acht Blöcke sind Fließtext, drei bleiben: das ausdrücklich unverbindliche Übersichtsmuster, der Hintergrund zum Cross-Version-Extension-Pattern, der Verweis auf künftig unterstützte Konfigurationen. Das Intro benennt die Konvention.

Betroffen waren unter anderem beide `Variabilität`-Regeln — die Überführung des 4-Schemas in die Segmentform sah wie ein Hinweis aus.

## 3. Variable Angaben in den täglichen Schemata abgewiesen

```
vorher:  when = MORN, frequencyMax = 3   →  1-0-0-0 Stück
neu:     Abbruch
```

`frequencyMax` und `periodMax` waren nur bei den Wochentagsregeln ausgeschlossen. `TimingOnlyOneType` verlangt sie in jedem Zweig leer; die Spec war ohne Grund permissiver.

`hatZulaessigeLegacyFelder` nimmt jetzt die Periodeneinheit als Parameter — `'wk'` für Regel 4 und 5, `'d'` für Regel 3 und 6.

## 4. Alle Dosage-Elemente gegen das erkannte Schema geprüft

Die Erkennung stützte sich allein auf Element 1. Ein abweichendes späteres Element entfiel bei der Textbildung, mit ihm eine vollständige Gabe:

| Eingabe | vorher | verloren |
|---|---|---|
| `when=MORN` (1 St.) + `dayOfWeek=mon` (2 St.) | `1-0-0-0 Stück` | Montagsdosis |
| `when=MORN` + `timeOfDay=20:00` (2 St.) | `1-0-0-0 Stück` | Abenddosis |
| `dayOfWeek=mon` + `when=EVE` (2 St.) | `montags — je 1 Stück` | Abenddosis |

Jedes weitere Element wird jetzt einzeln klassifiziert und muss dasselbe Schema ergeben.

## 5. maxDosePerPeriod auf reine Bedarfsdosierung beschränkt

Analog zum Mindestabstand aus PR #14: zusammen mit einem `timing` bricht der Algorithmus ab. Ein Rhythmus legt bereits fest, wie viel im Bezugszeitraum angewendet wird. Im Profil setzt das `MaxDoseOnlyPureAsNeeded` durch.

`MaxDosePerPeriodIdentical` entfällt aus der Aufzählung der Konsistenz-Invarianten — mit `timing.empty()` erlaubt `AsNeededSingleDosageOnly` nur ein `Dosage`-Element.

## Verifiziert

```
when + frequencyMax             → Abbruch
when | dayOfWeek                → Abbruch
maxDose + Rhythmus              → Abbruch

when + Legacy 1 d               1-0-1-0 Stück
Wochentag + Legacy 1 wk         montags — je 1 Stück
Legacy nur in Element 2         1-0-2-0 Stück
maxDose ohne timing             bei Bedarf: je 1 Stück — nicht mehr als 4 Stück in 24 Stunden
reines Intervall                2 x alle 8 Stunden: je 1 Stück
```

90 Tests grün.
