### PR TITLE
Version 2.0.0-alpha1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Daraus folgt für jeden Eintrag:
 
 Ändert sich nur die Referenzimplementierung, bleibt die Versionsnummer stehen.
 
-## [2.0.0] - tbd
+## [2.0.0-alpha1] - 2026-08-27
 
 ### Algorithmus
 

--- a/dosage-text-algorithm-spec.md
+++ b/dosage-text-algorithm-spec.md
@@ -587,7 +587,7 @@ Andere Profilverletzungen können je nach fehlendem Feld dennoch zu einem unvoll
 
 Die Version des verwendeten Algorithmus MUSS über die Extension [GeneratedDosageInstructionsMeta](https://ig.fhir.de/igs/medication/StructureDefinition-GeneratedDosageInstructionsMeta.html) gesetzt werden. So lassen sich Textinhalt und verwendete Algorithmus-Version nachvollziehbar prüfen.
 
-Diese Seite beschreibt die Algorithmus-Version **2.0.0**. Die Nummer bezeichnet den hier festgelegten Algorithmus, nicht ein einzelnes Programm: Die Beispielimplementierung führt sie in `__version__` und gibt sie beim Erzeugen der Beispiele in `algorithmVersion` weiter. Eine eigene Implementierung trägt dieselbe Nummer ein, sobald sie diesen Algorithmus umsetzt.
+Diese Seite beschreibt die Algorithmus-Version **2.0.0-alpha1**. Die Nummer bezeichnet den hier festgelegten Algorithmus, nicht ein einzelnes Programm: Die Beispielimplementierung führt sie in `__version__` und gibt sie beim Erzeugen der Beispiele in `algorithmVersion` weiter. Eine eigene Implementierung trägt dieselbe Nummer ein, sobald sie diesen Algorithmus umsetzt.
 
 Damit bestimmt dieses Dokument die Versionsfolge: **Eine neue Versionsnummer entsteht genau dann, wenn sich diese Spezifikation ändert.** Korrekturen, die ausschließlich die Referenzimplementierung, ihre Tests oder die CI betreffen, ändern das festgelegte Verhalten nicht und lassen die Nummer unberührt. Die Versionshistorie führt [CHANGELOG.md](CHANGELOG.md); dort trennt jeder Eintrag beides voneinander.
 

--- a/medication-dosage-to-text.py
+++ b/medication-dosage-to-text.py
@@ -40,7 +40,7 @@ import os
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-__version__ = "2.0.0"
+__version__ = "2.0.0-alpha1"
 __language__ = "de-DE"
 
 class MedicationDosageTextGenerator:

--- a/tests/test_medication_dosage_to_text.py
+++ b/tests/test_medication_dosage_to_text.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import unittest
+import pathlib
 from pathlib import Path
 
 
@@ -662,8 +663,15 @@ class MedicationDosageTextTest(unittest.TestCase):
             "wöchentlich: morgens — je 1 Stück",
         )
 
-    def test_algorithm_version_is_2_0_0(self):
-        self.assertEqual(MODULE.__version__, "2.0.0")
+    def test_algorithm_version_matches_spec(self):
+        """__version__ wird als algorithmVersion in jede Ressource geschrieben.
+
+        Der Wert muss mit der Versionsangabe der Spezifikation uebereinstimmen;
+        beim Tag-Push prueft die CI zusaetzlich gegen den Tag.
+        """
+        spec = (pathlib.Path(__file__).resolve().parents[1]
+                / "dosage-text-algorithm-spec.md").read_text(encoding="utf-8")
+        self.assertIn(f"Algorithmus-Version **{MODULE.__version__}**", spec)
 
     def test_all_supported_resource_types_use_their_dosage_field(self):
         dosage = self.dosage(


### PR DESCRIPTION
Vorbereitung des Releases `2.0.0-alpha1`.

## Geändert

- `medication-dosage-to-text.py` — `__version__ = "2.0.0-alpha1"`
- `dosage-text-algorithm-spec.md` — Versionsangabe im Abschnitt Versionierung
- `CHANGELOG.md` — Überschrift `[2.0.0-alpha1]` mit Datum

Die Nummer landet über `__version__` als `algorithmVersion` in jeder vom Medication IG DE erzeugten Ressource; beim Tag-Push vergleicht die CI sie gegen den Tag.

## Test angepasst

`test_algorithm_version_is_2_0_0` war fest auf `"2.0.0"` verdrahtet und hätte bei jedem Versionswechsel nachgezogen werden müssen. Er vergleicht `__version__` jetzt gegen die Versionsangabe der Spezifikation — damit fällt auf, wenn beide auseinanderlaufen, statt dass der Test bei jeder Erhöhung stumpf angepasst wird.

90 Tests grün.