### PR TITLE
Version 2.0.0-ballot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Daraus folgt für jeden Eintrag:
 
 Ändert sich nur die Referenzimplementierung, bleibt die Versionsnummer stehen.
 
+## [2.0.0-ballot] - 2026-08-30
+
+Inhaltlich identisch zu `2.0.0-alpha1`; die Version markiert den Stand, der in das Kommentierungsverfahren geht.
+
 ## [2.0.0-alpha1] - 2026-08-27
 
 ### Algorithmus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,6 @@ Daraus folgt für jeden Eintrag:
 
 ## [2.0.0-ballot] - 2026-08-30
 
-Inhaltlich identisch zu `2.0.0-alpha1`; die Version markiert den Stand, der in das Kommentierungsverfahren geht.
-
-## [2.0.0-alpha1] - 2026-08-27
-
 ### Algorithmus
 
 #### Added

--- a/dosage-text-algorithm-spec.md
+++ b/dosage-text-algorithm-spec.md
@@ -587,7 +587,7 @@ Andere Profilverletzungen können je nach fehlendem Feld dennoch zu einem unvoll
 
 Die Version des verwendeten Algorithmus MUSS über die Extension [GeneratedDosageInstructionsMeta](https://ig.fhir.de/igs/medication/StructureDefinition-GeneratedDosageInstructionsMeta.html) gesetzt werden. So lassen sich Textinhalt und verwendete Algorithmus-Version nachvollziehbar prüfen.
 
-Diese Seite beschreibt die Algorithmus-Version **2.0.0-alpha1**. Die Nummer bezeichnet den hier festgelegten Algorithmus, nicht ein einzelnes Programm: Die Beispielimplementierung führt sie in `__version__` und gibt sie beim Erzeugen der Beispiele in `algorithmVersion` weiter. Eine eigene Implementierung trägt dieselbe Nummer ein, sobald sie diesen Algorithmus umsetzt.
+Diese Seite beschreibt die Algorithmus-Version **2.0.0-ballot**. Die Nummer bezeichnet den hier festgelegten Algorithmus, nicht ein einzelnes Programm: Die Beispielimplementierung führt sie in `__version__` und gibt sie beim Erzeugen der Beispiele in `algorithmVersion` weiter. Eine eigene Implementierung trägt dieselbe Nummer ein, sobald sie diesen Algorithmus umsetzt.
 
 Damit bestimmt dieses Dokument die Versionsfolge: **Eine neue Versionsnummer entsteht genau dann, wenn sich diese Spezifikation ändert.** Korrekturen, die ausschließlich die Referenzimplementierung, ihre Tests oder die CI betreffen, ändern das festgelegte Verhalten nicht und lassen die Nummer unberührt. Die Versionshistorie führt [CHANGELOG.md](CHANGELOG.md); dort trennt jeder Eintrag beides voneinander.
 

--- a/medication-dosage-to-text.py
+++ b/medication-dosage-to-text.py
@@ -40,7 +40,7 @@ import os
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-__version__ = "2.0.0-alpha1"
+__version__ = "2.0.0-ballot"
 __language__ = "de-DE"
 
 class MedicationDosageTextGenerator:


### PR DESCRIPTION
Vorbereitung des Releases `2.0.0-ballot`. Inhaltlich identisch zu `2.0.0-alpha1` — nur die Versionsangaben.

- `medication-dosage-to-text.py` — `__version__ = "2.0.0-ballot"`
- `dosage-text-algorithm-spec.md` — Versionsangabe im Abschnitt Versionierung
- `CHANGELOG.md` — eigener Eintrag `[2.0.0-ballot]` mit dem Hinweis, dass er inhaltlich `2.0.0-alpha1` entspricht

Der Eintrag ersetzt `[2.0.0-alpha1]` nicht, weil diese Version veröffentlicht ist.

Die Nummer landet über `__version__` als `algorithmVersion` in jeder vom Medication IG DE erzeugten Ressource; beim Tag-Push vergleicht die CI sie gegen den Tag. 90 Tests grün.